### PR TITLE
Temporary workaround for issue #3915.

### DIFF
--- a/testsuite/scripts/tutorials/test_11-ferrofluid_1.py
+++ b/testsuite/scripts/tutorials/test_11-ferrofluid_1.py
@@ -22,7 +22,7 @@ import numpy as np
 
 tutorial, skipIfMissingFeatures = importlib_wrapper.configure_and_import(
     "@TUTORIALS_DIR@/11-ferrofluid/11-ferrofluid_part1.py",
-    equil_steps=200, equil_rounds=10)
+    equil_steps=200, equil_rounds=10, N=1200)
 
 
 @skipIfMissingFeatures


### PR DESCRIPTION
The bisection error seems to be box size dependent. In ferrofluid tutorial 1, the box size is determined by volume fraction + number of particles. Offline tests with the failing docker container showed that reducing the number of particles did not help. Increasing the particle number from 1000 to 1200 in the test seems to work around the issue.

For this tutorial the issue seems to only show up in the CI, the tutorial itself seems to run no matter what.
